### PR TITLE
Fix spaces in *CHARBUF typemap

### DIFF
--- a/include/ossl_typemaps.i
+++ b/include/ossl_typemaps.i
@@ -3,7 +3,7 @@
 /*
  * Use for writeable buffers of type char* passed as arguments
  */
-%typemap(gotype) char *CHARBUF %{ []byte %}
+%typemap(gotype) char *CHARBUF %{[]byte%}
 %typemap(in) char *CHARBUF {
     if ($input.len <= 0 || $input.cap <= 0) $1 = NULL;
     else $1 = (char*)malloc($input.cap);


### PR DESCRIPTION
Been having problems on 1.4 and 1.5 with the spaces.
